### PR TITLE
don't mention both Makefile.PL and Build.PL if both are present in the d...

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+    - only mention one installer tool even if both are in use, and prefer
+      Build.PL over Makefile.PL, just as cpan clients do
 
 1.200000  2012-05-22
     - New maintainer: Mike Doherty, doherty@cpan.org

--- a/lib/Dist/Zilla/Plugin/InstallGuide.pm
+++ b/lib/Dist/Zilla/Plugin/InstallGuide.pm
@@ -108,17 +108,21 @@ Builds and writes the C<INSTALL> file.
 sub setup_installer {
     my $self = shift;
     my $manual_installation = '';
-    for (@{ $self->zilla->files }) {
-        if ($_->name eq 'Makefile.PL') {
-            $manual_installation .= $makemaker_manual_installation;
-        }
-        elsif ($_->name eq 'Build.PL') {
-            $manual_installation .= $module_build_manual_installation;
-        }
+
+    my %installer = map { $_->name => 1 }
+        grep { $_->name eq 'Makefile.PL' or $_->name eq 'Build.PL' }
+        @{ $self->zilla->files };
+
+    if ($installer{'Build.PL'}) {
+        $manual_installation .= $module_build_manual_installation;
     }
-    unless (defined $manual_installation) {
+    elsif ($installer{'Makefile.PL'}) {
+        $manual_installation .= $makemaker_manual_installation;
+    }
+    unless ($manual_installation) {
         $self->log_fatal('neither Makefile.PL nor Build.PL is present, aborting');
     }
+
     require Dist::Zilla::File::InMemory;
     (my $main_package = $self->zilla->name) =~ s!-!::!g;
     my $content = $self->fill_in_string(


### PR DESCRIPTION
...ist

..which is now being done for some dists, via [MakeMaker::Fallback] and [ModuleBuildTiny]

also fixed a small bug where the lack of installer wasn't being detected (you check the definedness of $manual_installation, but it was initialized to the empty string).
