### PR TITLE
move to generating a FromCode file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+  - create file at in the GatherFiles phase and munge it with a FromCode file
+    type, to ensure the file exists early enough that other plugins can see it
 
 1.200002  2013-11-27
   - Re-release with a compile test that won't hang on


### PR DESCRIPTION
FromCode files have their code evaluated at the same time in-memory files are
evaluated, after the PrereqSource and InstallTool phases but before AfterBuild.
Consequently, the file's existence becomes visible to other plugins that run in
the file munging phase.  It also follows the same pattern as other plugins that
generate files dependent on prereq data, such as [MetaJSON] in core, therefore
resolving the alert generated by [VerifyPhases].

(Also mirrors similar patches made for [MakeMaker], [ModuleBuild], and [Test::ReportPrereqs].)

I couldn't build with your pluginbundle, as there are a few prereqs that don't install (Template-Toolkit, Devel-Cover, WWW-Shorten, libintl-perl), but I was successfully able to build and test with this modification to your dist.ini:

-[@Author::DOHERTY]
+[Bootstrap::lib]
+[@Author::ETHER]
+-remove = InstallGuide
+Git::GatherDir.exclude_filename[0] = Build.PL
+Git::GatherDir.exclude_filename[1] = Makefile.PL
+Git::GatherDir.exclude_filename[2] = README
+Git::GatherDir.exclude_filename[3] = README.mkdn
+
+;[@Author::DOHERTY]
 [InstallGuide]
